### PR TITLE
Introduce non-unique tags for milestones

### DIFF
--- a/packages/core/src/-private/milestone-handle.ts
+++ b/packages/core/src/-private/milestone-handle.ts
@@ -9,7 +9,8 @@ export default class MilestoneHandle implements HandleInterface {
   private resolution: Resolution | null = null;
 
   public constructor(
-    public name: MilestoneKey,
+    public id: MilestoneKey,
+    public tags: MilestoneKey[],
     private _coordinator: MilestoneCoordinator,
     private _action: () => unknown,
     private _deferred: Deferred<unknown>,
@@ -39,7 +40,7 @@ export default class MilestoneHandle implements HandleInterface {
   private _complete(resolution: Resolution, options: ResolutionOptions = {}, finalizer: () => void): Promise<void> {
     assert(
       !this.resolution || resolution === this.resolution,
-      `Multiple resolutions for milestone '${this.name.toString()}'`,
+      `Multiple resolutions for milestone '${this.id.toString()}'`,
     );
 
     if (!this.resolution) {

--- a/packages/core/src/-private/milestone-target.ts
+++ b/packages/core/src/-private/milestone-target.ts
@@ -8,13 +8,13 @@ const debug = logger('@milestones/core:target');
 export default class MilestoneTarget implements TargetInterface {
   private _coordinatorDeferred: Deferred<MilestoneHandle> = defer();
 
-  public constructor(public name: MilestoneKey) {}
+  public constructor(public key: MilestoneKey) {}
 
   public then<TResult1 = MilestoneHandle, TResult2 = never>(
     onfulfilled?: ((value: MilestoneHandle) => TResult1 | PromiseLike<TResult1>) | undefined | null,
     onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | undefined | null,
   ): Promise<TResult1 | TResult2> {
-    debug('awaiting arrival at milestone %s', this.name);
+    debug('awaiting arrival at milestone %s', this.key);
     return this._coordinatorDeferred.promise.then(onfulfilled, onrejected);
   }
 
@@ -32,6 +32,10 @@ export default class MilestoneTarget implements TargetInterface {
 
   public andCancel(options?: ResolutionOptions): Promise<void> {
     return this.then(milestone => milestone.cancel(options));
+  }
+
+  public toString(): string {
+    return `MilestoneTarget(${this.key.toString()})`;
   }
 
   // Called from the MilestoneCoordinator

--- a/packages/core/tests/coordinator-test.ts
+++ b/packages/core/tests/coordinator-test.ts
@@ -27,13 +27,26 @@ describe('MilestoneCoordinator', () => {
     expect(ACTIVE_COORDINATORS).to.deep.equal({});
   });
 
-  test('looking up the coordinator for a specific milestone', () => {
+  test('looking up the coordinator for a specific key', () => {
     let coordinator = new MilestoneCoordinator(['one', 'two']);
 
-    expect(MilestoneCoordinator.forMilestone('one')).to.equal(coordinator);
-    expect(MilestoneCoordinator.forMilestone('two')).to.equal(coordinator);
-    expect(MilestoneCoordinator.forMilestone('three')).to.equal(undefined);
+    expect(MilestoneCoordinator.forKey('one')).to.equal(coordinator);
+    expect(MilestoneCoordinator.forKey('two')).to.equal(coordinator);
+    expect(MilestoneCoordinator.forKey('three')).to.equal(undefined);
 
     coordinator.deactivateAll();
+  });
+
+  test('looking up the coordinator for a given id and set of tags', () => {
+    let coordinator1 = new MilestoneCoordinator(['one', 'two']);
+    let coordinator2 = new MilestoneCoordinator(['three', 'four']);
+
+    expect(MilestoneCoordinator.forMilestone('one', ['three'])).to.equal(coordinator1);
+    expect(MilestoneCoordinator.forMilestone('five', ['one', 'three'])).to.equal(coordinator1);
+    expect(MilestoneCoordinator.forMilestone('five', ['three', 'one'])).to.equal(coordinator2);
+    expect(MilestoneCoordinator.forMilestone('five', ['six', 'seven'])).to.equal(undefined);
+
+    coordinator1.deactivateAll();
+    coordinator2.deactivateAll();
   });
 });

--- a/packages/core/tests/sys-test.ts
+++ b/packages/core/tests/sys-test.ts
@@ -45,7 +45,7 @@ describe('System Hooks', () => {
     });
   });
 
-  describe('wrap', () => {
+  describe('run', () => {
     let isWrapped = false;
     beforeEach(() => {
       isWrapped = false;

--- a/packages/core/tests/tags-test.ts
+++ b/packages/core/tests/tags-test.ts
@@ -1,0 +1,39 @@
+import { describe, test, afterEach } from 'mocha';
+import { expect } from 'chai';
+import { milestone, advanceTo, activateMilestones, deactivateAllMilestones } from '../src/index';
+
+describe('Tags', () => {
+  afterEach(() => deactivateAllMilestones());
+
+  for (let [kind, key] of [['string', 'key'], ['symbol', Symbol('key')]]) {
+    describe(`with ${kind.toString()} keys`, () => {
+      test('activating by tag', async () => {
+        activateMilestones([key]);
+
+        let program = async (): Promise<string> => {
+          return await milestone(Symbol(), async () => 'hi', { tags: [key] });
+        };
+
+        let promise = program();
+        await advanceTo(key).andReturn('done');
+        expect(await promise).to.equal('done');
+      });
+
+      test('advancing by tags', async () => {
+        activateMilestones([key]);
+
+        let program = async (): Promise<[string, string]> => {
+          return await Promise.all([
+            milestone(Symbol(), async () => 'hello', { tags: [key] }),
+            milestone(Symbol(), async () => 'world', { tags: [key] }),
+          ]);
+        };
+
+        let promise = program();
+        await advanceTo(key).andContinue();
+        await advanceTo(key).andContinue();
+        expect(await promise).to.deep.equal(['hello', 'world']);
+      });
+    });
+  }
+});


### PR DESCRIPTION
This introduces a notion of 'tags' for milestones as described in https://github.com/salsify/milestones/issues/4#issuecomment-423394522.

Up to now in the code (and colloquially) we've used "key" and "name" fairly interchangeably when referring to the way we identify milestones. A fair amount of the diff here is being more precise about that: 
  - milestones have a unique `id` (formerly `name`, but `id` is more descriptive)
  - milestones have an optional set of `tags` that may be shared among multiple pending milestones
  - a `key` is any string or symbol value that's used as either an `id` or `tag`

/cc @salsify/frontend-developers 
