### PR TITLE
Accept a default handler when activating milestones

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "lint": "eslint . --ext ts,js",
     "test": "mocha -r ts-node/register tests/**/*.ts",
+    "test:watch": "mocha -r ts-node/register --watch --extension ts 'tests/**/*.ts'",
     "build": "yarn clean && tsc",
     "clean": "rimraf dist",
     "prepublishOnly": "yarn build",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,8 +13,8 @@ const debugInactive = logger('@milestones/core:inactive');
  * Inactive milestones will pass through to their given callbacks as though the
  * milestone wrapper weren't present at all.
  */
-export function activateMilestones(keys: MilestoneKey[]): MilestoneCoordinator {
-  return new CoordinatorImpl(keys);
+export function activateMilestones(keys: MilestoneKey[], options?: ActivationOptions): MilestoneCoordinator {
+  return new CoordinatorImpl(keys, options);
 }
 
 /**
@@ -22,6 +22,19 @@ export function activateMilestones(keys: MilestoneKey[]): MilestoneCoordinator {
  */
 export function deactivateAllMilestones(): void {
   CoordinatorImpl.deactivateAll();
+}
+
+export interface ActivationOptions {
+  /**
+   * A callback to be invoked whenever one of the activated milestones in this
+   * set is reached, allowing you to specify default behavior for a set of
+   * milestones.
+   *
+   * Note that this callback *will not* be invoked for a milestone that you
+   * explicitly `advanceTo`, allowing you to override the default behavior
+   * on a case by case basis if desired.
+   */
+  onMilestoneReached?(milestone: MilestoneHandle): void;
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -245,24 +245,31 @@ export interface ResolutionOptions {
  * for calling `activateMilestones` in a `beforeEach()` block and `deactivateAll()` in
  * an `afterEach` block.
  */
-export function setupMilestones(keys: MilestoneKey[]): void;
-export function setupMilestones(hooks: TestHooks, keys: MilestoneKey[]): void;
-export function setupMilestones(...params: [MilestoneKey[]] | [TestHooks, MilestoneKey[]]): void {
+export function setupMilestones(keys: MilestoneKey[], options?: ActivationOptions): void;
+export function setupMilestones(hooks: TestHooks, keys: MilestoneKey[], options?: ActivationOptions): void;
+export function setupMilestones(
+  hooksOrKeys: MilestoneKey[] | TestHooks,
+  keysOrOptions: MilestoneKey[] | ActivationOptions | undefined,
+  maybeOptions?: ActivationOptions,
+): void {
   let milestones: MilestoneCoordinator;
   let keys: MilestoneKey[];
   let hooks: TestHooks;
+  let options: ActivationOptions | undefined;
 
-  if (params.length === 1) {
+  if (Array.isArray(hooksOrKeys)) {
     // @ts-ignore
     hooks = { beforeEach, afterEach };
-    keys = params[0];
+    keys = hooksOrKeys as MilestoneKey[];
+    options = keysOrOptions as ActivationOptions | undefined;
   } else {
-    hooks = params[0];
-    keys = params[1];
+    hooks = hooksOrKeys as TestHooks;
+    keys = keysOrOptions as MilestoneKey[];
+    options = maybeOptions;
   }
 
   hooks.beforeEach(function() {
-    milestones = activateMilestones(keys);
+    milestones = activateMilestones(keys, options);
   });
 
   hooks.afterEach(function() {


### PR DESCRIPTION
This introduces a notion of a default milestone handler as described in https://github.com/salsify/milestones/issues/4#issuecomment-423394522.

In combination with #16, this provides a fairly neat way to e.g. skip timeouts during testing.

<details>
<summary>Example</summary>

```ts
// .../timeout.ts

import { milestone, setupMilestones } from '@milestones/core';

const TIMEOUT = Symbol('timeout');

export function timeout(duration: number) {
  return milestone(
    Symbol('anonymous timeout'),
    () => new Promise(resolve => setTimeout(resolve, duration)),
    { tags: [TIMEOUT] }
  );
}

export function skipTimeouts(hooks: TestHooks = self) {
  setupMilestones(hooks, [TIMEOUT], {
    onMilestoneReached: handle => handle.return(),
  });
}
```

And then you can import and use `timeout` as you would anywhere (maybe with an overload to allow explicitly giving it an ID instead of always generating one) and call `skipTimeouts` in your test setup.
</details>

/cc @salsify/frontend-developers 
