### PR TITLE
use requirejs instead of require for fastboot compat

### DIFF
--- a/packages/ember/addon/index.ts
+++ b/packages/ember/addon/index.ts
@@ -3,16 +3,16 @@ import { run } from '@ember/runloop';
 import EmberObject from '@ember/object';
 import { registerSystem } from '@milestones/core';
 
-declare const require: {
+declare const requirejs: {
   (module: string): any; // eslint-disable-line
   has(module: string): boolean;
 };
 
 registerSystem({ run, defer });
 
-if (require.has('ember-concurrency')) {
-  const getRunningInstance = require('ember-concurrency/-task-instance').getRunningInstance;
-  const taskMacro = require('ember-concurrency').task;
+if (requirejs.has('ember-concurrency')) {
+  const getRunningInstance = requirejs('ember-concurrency/-task-instance').getRunningInstance;
+  const taskMacro = requirejs('ember-concurrency').task;
   class TaskHost extends EmberObject.extend({
     started: false,
     realPromise: null as unknown,


### PR DESCRIPTION
I've run into an issue with running enhanced-content-renderer tests in FastBoot (via ember-cli-fastboot-testing) where `require` is Node's CommonJS `require` instead of the Ember loader's `require`. This fixes the issue by using Ember loader's [`requirejs` alias](https://github.com/ember-cli/loader.js/blob/2f1a56a34b45df6b4a447d1e492b5901867126d3/lib/loader/loader.js#L46) instead of `require`.