### PR TITLE
ember-concurrency 2 compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,5 @@ script:
   - yarn build
   - yarn workspace @milestones/ember test
   - env STRIP_MILESTONES=true yarn workspace @milestones/ember test
+  - yarn workspace @milestones/ember add ember-concurrency@latest --dev
+  - yarn workspace @milestones/ember test

--- a/packages/ember/addon/index.ts
+++ b/packages/ember/addon/index.ts
@@ -11,7 +11,10 @@ declare const requirejs: {
 registerSystem({ run, defer });
 
 if (requirejs.has('ember-concurrency')) {
-  const getRunningInstance = requirejs('ember-concurrency/-task-instance').getRunningInstance;
+  const getRunningInstanceModule = requirejs.has('ember-concurrency/-private/external/task-instance/executor')
+    ? requirejs('ember-concurrency/-private/external/task-instance/executor')
+    : requirejs('ember-concurrency/-task-instance');
+  const getRunningInstance = getRunningInstanceModule.getRunningInstance;
   const taskMacro = requirejs('ember-concurrency').task;
   class TaskHost extends EmberObject.extend({
     started: false,


### PR DESCRIPTION
ember-concurrency 2.x moved `getRunningInstance` from `ember-concurrency/-task-instance` to `ember-concurrency/-private/external/task-instance/executor`.

Testing this would probably be better served with ember-try, but since it's not already set up on this repo, I did it the quick and dirty way 🙂 .